### PR TITLE
fix: client types when using async and this

### DIFF
--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -4,6 +4,9 @@ const cwd = await fn.getCWD()
 const hi = await fn.sayHi('world')
 const hi2 = await fn.sayHi('world')
 const hi3 = await fn.$cacheless.sayHi('world')
+const heyThere = await fn.sayHey()
+const heyYou = await fn.sayHey("you")
+const hello = await fn.sayHello(200)
 </script>
 
 <template>
@@ -12,5 +15,8 @@ const hi3 = await fn.$cacheless.sayHi('world')
     <div>{{ hi }}</div>
     <div>{{ hi2 }}</div>
     <div>{{ hi3 }} (nocache)</div>
+    <div>{{ heyThere }}</div>
+    <div>{{ heyYou }}</div>
+    <div>{{ hello }}</div>
   </div>
 </template>

--- a/playground/server/functions/hi.ts
+++ b/playground/server/functions/hi.ts
@@ -1,5 +1,16 @@
+import type { H3Event } from "h3"
+
 export async function sayHi(name: string) {
   // eslint-disable-next-line no-console
   console.log(`Hi ${name}`)
   return `Hello ${name} from server, ${Date.now()}`
+}
+
+export function sayHey(this: H3Event, name: string = "there") {
+  return `Hey ${name}! from ${this.path}, ${Date.now()}`
+}
+
+export async function sayHello(this: H3Event, ms: number = 1000) {
+  await new Promise((resolve) => setTimeout(resolve, ms))
+  return `Hello after ${ms}ms from ${this.path}, ${Date.now()}`
 }

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -9,7 +9,7 @@ export type ArgumentsType<T> = T extends (...args: infer A) => any ? A : never
 export type ReturnType<T> = T extends (...args: any) => infer R ? R : never
 
 export type Promisify<T> = ReturnType<T> extends Promise<any>
-  ? T
+  ? (...args: ArgumentsType<T>) => ReturnType<T>
   : (...args: ArgumentsType<T>) => Promise<Awaited<ReturnType<T>>>
 
 export type FunctionsClient<T> = {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When using `this` on an async function on the server, client side generated typings are wrong because it treats this as a parameter to be sent on the client side.

### Linked Issues


### Additional context
if you create a function on `server/functions` that is async and uses `this` like:

```ts
export async function sayHello(this: H3Event, ms: number = 1000) {
  await new Promise((resolve) => setTimeout(resolve, ms))
  return `Hello after ${ms}ms from ${this.path}, ${Date.now()}`
}
```

is generating type error:

<img width="1213" alt="Captura de pantalla 2023-08-30 a la(s) 9 21 04 p m" src="https://github.com/antfu/nuxt-server-fn/assets/1217807/c3d2be3d-0128-4fb5-9de2-28816ac24d27">

this PR fixes that by replacing `Promisify` implementation with:
```ts
export type Promisify<T> = ReturnType<T> extends Promise<any>
  ? (...args: ArgumentsType<T>) => ReturnType<T>
  : (...args: ArgumentsType<T>) => Promise<Awaited<ReturnType<T>>>
```

<img width="845" alt="Captura de pantalla 2023-08-30 a la(s) 9 22 03 p m" src="https://github.com/antfu/nuxt-server-fn/assets/1217807/c84cc9fe-354c-4142-8f61-e3679219f574">

<!-- e.g. is there anything you'd like reviewers to focus on? -->
