### PR TITLE
Add support for functions in sub directories of server/functions

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -21,7 +21,7 @@ export default defineNuxtModule<ModuleOptions>({
     const {
       apiRoute,
     } = options
-    const extGlob = '*.{ts,js}'
+    const extGlob = '**/*.{ts,js}'
     const dirs = nuxt.options._layers.map(layer => join(layer.config.rootDir, 'server/functions'))
     const clientPath = join(nuxt.options.buildDir, 'server-fn-client.ts')
     const handlerPath = join(nuxt.options.buildDir, 'server-fn-handler.ts')


### PR DESCRIPTION


### Description

Adds support for functions that exist in folders under server/functions/, like "server/functions/users/user.ts"

### Linked Issues
#15 

### Additional context


