### PR TITLE
fix: use relative paths in templates

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -101,7 +101,7 @@ export default createServerFnAPI(Object.assign({}, ${files.map((_, idx) => `func
         (await Promise.all(
           dirs.map(dir => fg(extGlob, { cwd: dir, absolute: true, onlyFiles: true })),
         )
-        ).flat(),
+        ).flat().map(f => relative(nuxt.options.buildDir, f)),
       ))
       return files
     }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
This changes the function imports to be relative in the generated templates, I'm not sure if there are any documented conventions on making it relative, in my experience it works nicer with things like docker containers.

Before
```
import * as functions2 from "/Users/bobbiegoede/www/forks/nuxt-server-fn/playground/server/functions/hi"
import * as functions3 from "/Users/bobbiegoede/www/forks/nuxt-server-fn/playground/layers/my-layer/server/functions/from-layer"
```

After
```
import * as functions2 from "../server/functions/hi"
import * as functions3 from "../layers/my-layer/server/functions/from-layer"
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
